### PR TITLE
[PPC] Fix kgdb symbol resolution

### DIFF
--- a/gdb/kgdb.h
+++ b/gdb/kgdb.h
@@ -60,6 +60,9 @@ void fbsd_vmcore_set_supply_pcb (struct gdbarch *gdbarch,
 						     CORE_ADDR));
 void fbsd_vmcore_set_cpu_pcb_addr (struct gdbarch *gdbarch,
 				   CORE_ADDR (*cpu_pcb_addr) (u_int));
+void fbsd_vmcore_set_kern_disp (struct gdbarch *gdbarch,
+			CORE_ADDR (*kern_disp) (struct gdbarch *,
+						const char *, const char *));
 
 CORE_ADDR kgdb_lookup(const char *sym);
 

--- a/gdb/ppcfbsd-kern.c
+++ b/gdb/ppcfbsd-kern.c
@@ -59,11 +59,11 @@ ppcfbsd_supply_pcb(struct regcache *regcache, CORE_ADDR pcb_addr)
 		memset(&pcb, 0, sizeof(pcb));
 
 	/*
-	 * r14-r31 are saved in the pcb
+	 * r12-r31 are saved in the pcb
 	 */
-	for (i = 14; i <= 31; i++) {
+	for (i = 12; i <= 31; i++) {
 		regcache->raw_supply(tdep->ppc_gp0_regnum + i,
-		    (char *)&pcb.pcb_context[i]);
+		    (char *)&pcb.pcb_context[i - 12]);
 	}
 
 	/* r1 is saved in the sp field */
@@ -75,6 +75,7 @@ ppcfbsd_supply_pcb(struct regcache *regcache, CORE_ADDR pcb_addr)
 			      (char *)&pcb.pcb_toc);
 
 	regcache->raw_supply(tdep->ppc_lr_regnum, (char *)&pcb.pcb_lr);
+	regcache->raw_supply(PPC_PC_REGNUM, (char *)&pcb.pcb_lr);
 	regcache->raw_supply(tdep->ppc_cr_regnum, (char *)&pcb.pcb_cr);
 }
 #endif


### PR DESCRIPTION
PowerPC kernels are fully relocatable and may be loaded at any memory
address. In order to resolve symbols properly, GDB must relocate the
kernel object file to match the image loaded in memory.

This pull request addresses the issues of https://reviews.freebsd.org/D21946.

Similar to GDB's remote_open(), that may relocate the debugged binary with the info returned by the "qOffsets" packet, this change may relocate the kernel on fbsd_kvm_target_open(), with the info returned by the arch part of kgdb.

The code to relocate the kernel was inspired by svr4_relocate_main_executable(), that relocates PIE executables, by calling svr4_exec_displacement() to find the PIE displacement, building new section offsets and then calling objfile_relocate(). In this change's case, it is the architecture dependent kern_disp function that finds out the kernel displacement.