### PR TITLE
[PPC] Fix kgdb symbol resolution (v2)

### DIFF
--- a/gdb/aclocal.m4
+++ b/gdb/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
+# generated automatically by aclocal 1.16.1 -*- Autoconf -*-
 
-# Copyright (C) 1996-2017 Free Software Foundation, Inc.
+# Copyright (C) 1996-2018 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -14,7 +14,7 @@
 m4_ifndef([AC_CONFIG_MACRO_DIRS], [m4_defun([_AM_CONFIG_MACRO_DIRS], [])m4_defun([AC_CONFIG_MACRO_DIRS], [_AM_CONFIG_MACRO_DIRS($@)])])
 # AM_AUX_DIR_EXPAND                                         -*- Autoconf -*-
 
-# Copyright (C) 2001-2017 Free Software Foundation, Inc.
+# Copyright (C) 2001-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -66,7 +66,7 @@ am_aux_dir=`cd "$ac_aux_dir" && pwd`
 
 # AM_CONDITIONAL                                            -*- Autoconf -*-
 
-# Copyright (C) 1997-2017 Free Software Foundation, Inc.
+# Copyright (C) 1997-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -97,7 +97,7 @@ AC_CONFIG_COMMANDS_PRE(
 Usually this means the macro was only invoked conditionally.]])
 fi])])
 
-# Copyright (C) 2001-2017 Free Software Foundation, Inc.
+# Copyright (C) 2001-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -121,7 +121,7 @@ AC_SUBST([install_sh])])
 # Add --enable-maintainer-mode option to configure.         -*- Autoconf -*-
 # From Jim Meyering
 
-# Copyright (C) 1996-2017 Free Software Foundation, Inc.
+# Copyright (C) 1996-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -154,7 +154,7 @@ AC_MSG_CHECKING([whether to enable maintainer-specific portions of Makefiles])
 ]
 )
 
-# Copyright (C) 2001-2017 Free Software Foundation, Inc.
+# Copyright (C) 2001-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -182,7 +182,7 @@ fi
 INSTALL_STRIP_PROGRAM="\$(install_sh) -c -s"
 AC_SUBST([INSTALL_STRIP_PROGRAM])])
 
-# Copyright (C) 2006-2017 Free Software Foundation, Inc.
+# Copyright (C) 2006-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,

--- a/gdb/config.in
+++ b/gdb/config.in
@@ -219,6 +219,9 @@
 /* Define to 1 if your system has the kinfo_getvmmap function. */
 #undef HAVE_KINFO_GETVMMAP
 
+/* Define to 1 if your system has the kvm_kerndisp function. */
+#undef HAVE_KVM_DISP
+
 /* Define to 1 if your system has the kvm_open2 function. */
 #undef HAVE_KVM_OPEN2
 

--- a/gdb/configure
+++ b/gdb/configure
@@ -1646,8 +1646,8 @@ Some influential environment variables:
   MAKEINFOFLAGS
               Parameters for MAKEINFO.
   YACC        The `Yet Another Compiler Compiler' implementation to use.
-              Defaults to the first program found out of: `bison -y', `byacc',
-              `yacc'.
+              Defaults to the first program found out of: `bison -o y.tab.c',
+              `byacc', `yacc'.
   YFLAGS      The list of arguments that will be passed by default to $YACC.
               This script will default YFLAGS to the empty string to avoid a
               default value of `-d' given by some make applications.
@@ -7384,7 +7384,7 @@ else
   RANLIB="$ac_cv_prog_RANLIB"
 fi
 
-for ac_prog in 'bison -y' byacc
+for ac_prog in 'bison -o y.tab.c' byacc
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
@@ -8110,7 +8110,7 @@ fi
 # kgdb needs kvm_open2 for cross-debugging
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing kvm_open2" >&5
 $as_echo_n "checking for library containing kvm_open2... " >&6; }
-if test "${ac_cv_search_kvm_open2+set}" = set; then :
+if ${ac_cv_search_kvm_open2+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_func_search_save_LIBS=$LIBS
@@ -8144,11 +8144,11 @@ for ac_lib in '' kvm; do
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test "${ac_cv_search_kvm_open2+set}" = set; then :
+  if ${ac_cv_search_kvm_open2+:} false; then :
   break
 fi
 done
-if test "${ac_cv_search_kvm_open2+set}" = set; then :
+if ${ac_cv_search_kvm_open2+:} false; then :
 
 else
   ac_cv_search_kvm_open2=no
@@ -8163,6 +8163,66 @@ if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 $as_echo "#define HAVE_KVM_OPEN2 1" >>confdefs.h
+
+fi
+
+
+# kgdb needs kvm_kerndisp for relocatable kernels
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing kvm_kerndisp" >&5
+$as_echo_n "checking for library containing kvm_kerndisp... " >&6; }
+if ${ac_cv_search_kvm_kerndisp+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char kvm_kerndisp ();
+int
+main ()
+{
+return kvm_kerndisp ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' kvm; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_kvm_kerndisp=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_kvm_kerndisp+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_kvm_kerndisp+:} false; then :
+
+else
+  ac_cv_search_kvm_kerndisp=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_kvm_kerndisp" >&5
+$as_echo "$ac_cv_search_kvm_kerndisp" >&6; }
+ac_res=$ac_cv_search_kvm_kerndisp
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+$as_echo "#define HAVE_KVM_DISP 1" >>confdefs.h
 
 fi
 

--- a/gdb/configure.ac
+++ b/gdb/configure.ac
@@ -516,6 +516,11 @@ AC_SEARCH_LIBS(kvm_open2, kvm,
   [AC_DEFINE(HAVE_KVM_OPEN2, 1,
             [Define to 1 if your system has the kvm_open2 function. ])])
 
+# kgdb needs kvm_kerndisp for relocatable kernels
+AC_SEARCH_LIBS(kvm_kerndisp, kvm,
+  [AC_DEFINE(HAVE_KVM_DISP, 1,
+            [Define to 1 if your system has the kvm_kerndisp function. ])])
+
 AM_ICONV
 
 # GDB may fork/exec the iconv program to get the list of supported character

--- a/gdb/fbsd-kvm.c
+++ b/gdb/fbsd-kvm.c
@@ -331,6 +331,26 @@ fbsd_kvm_target_open (const char *args, int from_tty)
 	discard_cleanups(old_chain);
 	unpush_target(&fbsd_kvm_ops);
 
+	/* Relocate kernel objfile if needed. */
+	if (symfile_objfile &&
+	    (bfd_get_file_flags(symfile_objfile->obfd) &
+	      (EXEC_P | DYNAMIC)) != 0) {
+		struct section_offsets *new_offsets;
+		int i;
+		CORE_ADDR displacement;
+
+		displacement = kvm_kerndisp(nkvm);
+		if (displacement != 0) {
+			new_offsets = XALLOCAVEC (struct section_offsets,
+				symfile_objfile->num_sections);
+
+			for (i = 0; i < symfile_objfile->num_sections; i++)
+				new_offsets->offsets[i] = displacement;
+
+			objfile_relocate(symfile_objfile, new_offsets);
+		}
+	}
+
 	/*
 	 * Determine the first address in KVA.  Newer kernels export
 	 * VM_MAXUSER_ADDRESS and the first kernel address can be

--- a/gdb/fbsd-kvm.c
+++ b/gdb/fbsd-kvm.c
@@ -331,6 +331,7 @@ fbsd_kvm_target_open (const char *args, int from_tty)
 	discard_cleanups(old_chain);
 	unpush_target(&fbsd_kvm_ops);
 
+#ifdef HAVE_KVM_DISP
 	/* Relocate kernel objfile if needed. */
 	if (symfile_objfile &&
 	    (bfd_get_file_flags(symfile_objfile->obfd) &
@@ -350,6 +351,7 @@ fbsd_kvm_target_open (const char *args, int from_tty)
 			objfile_relocate(symfile_objfile, new_offsets);
 		}
 	}
+#endif
 
 	/*
 	 * Determine the first address in KVA.  Newer kernels export

--- a/gdb/gdbserver/aclocal.m4
+++ b/gdb/gdbserver/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
+# generated automatically by aclocal 1.16.1 -*- Autoconf -*-
 
-# Copyright (C) 1996-2017 Free Software Foundation, Inc.
+# Copyright (C) 1996-2018 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -14,7 +14,7 @@
 m4_ifndef([AC_CONFIG_MACRO_DIRS], [m4_defun([_AM_CONFIG_MACRO_DIRS], [])m4_defun([AC_CONFIG_MACRO_DIRS], [_AM_CONFIG_MACRO_DIRS($@)])])
 # AM_CONDITIONAL                                            -*- Autoconf -*-
 
-# Copyright (C) 1997-2017 Free Software Foundation, Inc.
+# Copyright (C) 1997-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -48,7 +48,7 @@ fi])])
 # Add --enable-maintainer-mode option to configure.         -*- Autoconf -*-
 # From Jim Meyering
 
-# Copyright (C) 1996-2017 Free Software Foundation, Inc.
+# Copyright (C) 1996-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -81,7 +81,7 @@ AC_MSG_CHECKING([whether to enable maintainer-specific portions of Makefiles])
 ]
 )
 
-# Copyright (C) 2006-2017 Free Software Foundation, Inc.
+# Copyright (C) 2006-2018 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,


### PR DESCRIPTION
PowerPC kernels are fully relocatable and may be loaded at any memory
address. In order to resolve symbols properly, GDB must relocate the
kernel object file to match the image loaded in memory.

---

This is an alternative to PR #10, based on the suggestion to move the code that finds out kernel displacement to libkvm. This new version depends on the following 2 changes:

- Add SYSCTL to get KERNBASE and relocated KERNBASE - https://reviews.freebsd.org/D23284
- WIP: Implement kvm_kerndisp - https://reviews.freebsd.org/D23285

This approach really looks better than the previous one. What do you think?