### PR TITLE
[PPC] Fix ppcfbsd_trapframe_sniffer

### DIFF
--- a/gdb/ppcfbsd-kern.c
+++ b/gdb/ppcfbsd-kern.c
@@ -192,8 +192,9 @@ ppcfbsd_trapframe_sniffer (const struct frame_unwind *self,
 
   pc = get_frame_func (this_frame);
   find_pc_partial_function (pc, &name, NULL, NULL);
-  if (name && (strcmp(name, "asttrapexit") == 0
-	       || strcmp(name, "trapexit") == 0))
+  if (name && (strcmp(name, "trapagain") == 0
+	       || strcmp(name, "trapexit") == 0
+	       || strcmp(name, "dbtrap") == 0))
     return 1;
 
   return 0;


### PR DESCRIPTION
It seems previous ppcfbsd_trapframe_sniffer() implementation assumed
it should work as FreeBSD's DDB, that compares the frame's return
address with some known sentinels.
In kgdb, however, the 'pc' obtained from 'this_frame' points to the
entry point of the function being executed in the frame.

Therefore, this patch checks if this_frame's function matches any of the
functions that may call C trap handling code.
This allows kgdb and remote kgdb to debug through traps.

This was tested on PowerPC64/AIM, but should work on PowerPC32/AIM
as well, given the trap code similarity between them. On BOOK-E,
"trap_common" function should probably be added to the list too,
but it would be better to test it first.